### PR TITLE
adding in development dependencies

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,16 @@ There are essentially two ways you can setup a Faction development environment. 
 
 If you're not working on Faction itself, but instead are developing modules, agents, transports, etc. You'll probably want to use containerized services so that the environment you're working with is as close to production as possible. 
 
+## Install development dependencies
+If doing development on an Ubuntu 18.04 LTS system, the following packages are required (for setup to complete):
+- python3, python3-dev, python3-setuptools, build-essential
+
+They can be installed via the following command:
+```
+sudo apt update
+sudo apt install python3 python3-dev python3-setuptools build-essential
+```
+
 ### Clean Environment (No Containers)
 1. Clone the following repositories to your computer
 ```


### PR DESCRIPTION
adding in required dependencies when doing a clean install to do development via: https://www.factionc2.com/docs/development/#clean-environment-no-containers

the python setup and faction setup commands will fail otherwise.  ubuntu 18.04 LTS does come with python3 and build-essential, but not with python3-setuptools or python3-dev

once those are present on the system setup will work fine.